### PR TITLE
expaneded gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ config.status
 dhcping
 *.o
 .deps
+compile
+autom4te.cache/

--- a/compile
+++ b/compile
@@ -1,0 +1,1 @@
+/usr/share/automake-1.14/compile


### PR DESCRIPTION
newer versions of automake create a cache folder that should not go into git.  The file 'compile' is generated per system by autogen.sh and thus should not be stored in git.
